### PR TITLE
block creation of File['root_npmrc'] when running on Windows

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -50,12 +50,14 @@ class nodejs::install {
     }
   }
 
-  file { 'root_npmrc':
-    ensure  => 'file',
-    path    => "${facts['root_home']}/.npmrc",
-    content => template('nodejs/npmrc.erb'),
-    owner   => 'root',
-    group   => '0',
-    mode    => '0600',
+  if $facts['os']['name'] != 'Windows' {
+    file { 'root_npmrc':
+      ensure  => 'file',
+      path    => "${facts['root_home']}/.npmrc",
+      content => template('nodejs/npmrc.erb'),
+      owner   => 'root',
+      group   => '0',
+      mode    => '0600',
+    }
   }
 }


### PR DESCRIPTION
This file resource causes the puppet-nodejs module to fail on Windows.

Excluding it seems to make the module work.   Installed node-red and node-red-contrib-amqp on Windows via npm package provider successfully after this change.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
